### PR TITLE
Add python-midonetclient to the dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prerequisites
 -------------
 
 * [protobuf (== 2.6.1)](https://pypi.python.org/pypi/protobuf/2.6.1)
+* [python-midonetclinet](https://github.com/midonet/python-midonetclient)
 
 Deployment to slaves
 --------------------

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
-sudo aptitude -y install python-pip
+sudo aptitude -y install python-pip unzip
 sudo pip install protobuf
+curl -o /tmp/python-midonetclient.zip https://codeload.github.com/midonet/python-midonetclient/zip/master
+unzip -d /tmp /tmp/python-midonetclient.zip
+cd /tmp/python-midonetclient-master
+sudo python setup.py install


### PR DESCRIPTION
These two patches add the installation of python-midonetclient to `scripts/setup.sh`.
